### PR TITLE
Enabled caching of mapped concepts, fixed a few issues from connectathon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ api/.settings/
 api/target/
 omod/target/
 *.iml
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 #SHR CDA Handler Module
 
-This module accepts CDA messages sent from the SHR REST module, parses them into OpenMRS objects, and persit them in the database.
+This module accepts CDA messages sent from the SHR REST module, parses them into OpenMRS objects, and persist them in the database.
+
+To upload this module to OpenMRS you need to have the latest compatible CIEL dictionary loaded into your OpenMRS instance. For more details see: https://wiki.openmrs.org/display/docs/Getting+and+Using+the+MVP-CIEL+Concept+Dictionary
+
+
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>shr-cdahandler</artifactId>
-		<version>0.5.1</version>
+		<version>0.6.0</version>
 	</parent>
 
 	<artifactId>shr-cdahandler-api</artifactId>
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>shr-contenthandler-api</artifactId>
-			<version>2.0.0</version>
+			<version>2.2.0</version>
 			<type>jar</type>
 			<scope>provided</scope>
 		</dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>shr-cdahandler</artifactId>
-		<version>0.5.0</version>
+		<version>0.5.1</version>
 	</parent>
 
 	<artifactId>shr-cdahandler-api</artifactId>

--- a/api/src/main/java/org/openmrs/module/shr/cdahandler/contenthandler/CdaContentHandler.java
+++ b/api/src/main/java/org/openmrs/module/shr/cdahandler/contenthandler/CdaContentHandler.java
@@ -89,7 +89,7 @@ public class CdaContentHandler implements ContentHandler {
 
 			// HACK: Handle the BOM or Java String Problems
 			int offset = 0;
-			byte[] data = content.getRawData();
+			byte[] data = content.getPayload();
 			while(data[offset] != '<')
 				offset++;
 
@@ -139,10 +139,6 @@ public class CdaContentHandler implements ContentHandler {
 	        }
 	        
         	return lastEncounter;
-        }
-        catch (IOException e) {
-	        log.error("Error generated", e);
-	        return null;
         }
         catch (DocumentImportException e) {
         	throw new RuntimeException(e);

--- a/api/src/main/java/org/openmrs/module/shr/cdahandler/processor/util/AssignedEntityProcessorUtil.java
+++ b/api/src/main/java/org/openmrs/module/shr/cdahandler/processor/util/AssignedEntityProcessorUtil.java
@@ -184,7 +184,8 @@ public final class AssignedEntityProcessorUtil {
 		// ie. root becomes an attribute and the extension becomes the value
 		// Anyways, for now represent in the standard ITI guidance for II data type
 		String id = this.m_datatypeUtil.emptyIdString();
-		if(this.m_configuration.getEpidRoot() == "" || this.m_configuration.getEpidRoot().isEmpty())
+        String epidRoot = this.m_configuration.getEpidRoot();
+		if(epidRoot.equals("") || epidRoot.isEmpty())
 		{
 			for(II autId : aut.getId())
 				if(autId.getRoot() != null)
@@ -200,9 +201,9 @@ public final class AssignedEntityProcessorUtil {
 					id = this.m_datatypeUtil.formatIdentifier(autId);
 		}
 		Provider res = null;
-		 
-		if (id.equals(this.m_datatypeUtil.emptyIdString())) 
-			throw new DocumentImportException("No data specified for author id");
+        if (id.equals(this.m_datatypeUtil.emptyIdString()))
+
+            			throw new DocumentImportException("No data specified for author id");
 		else 				
 			res = Context.getProviderService().getProviderByIdentifier(id);
 			

--- a/api/src/test/java/org/openmrs/module/shr/cdahandler/api/impl/test/CdaImportServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/shr/cdahandler/api/impl/test/CdaImportServiceImplTest.java
@@ -61,6 +61,7 @@ public class CdaImportServiceImplTest extends BaseModuleContextSensitiveTest  {
 		Context.getAdministrationService().setGlobalProperty(CdaHandlerConfiguration.PROP_VALIDATE_CONCEPT_STRUCTURE, "false");
 		Context.getAdministrationService().setGlobalProperty("order.nextOrderNumberSeed", "1");
 		Context.getAdministrationService().setGlobalProperty("order.nextOrderNumberSeed", "1");
+        Context.getAdministrationService().setGlobalProperty("shr-cdahandler.cacheMappedConcepts", "false");
 		Context.getAdministrationService().saveGlobalProperty(saveDir);
 		initializeInMemoryDatabase();
 		executeDataSet(ACTIVE_LIST_INITIAL_XML);

--- a/api/src/test/java/org/openmrs/module/shr/cdahandler/processor/document/impl/ihe/pcc/test/AntepartumSummaryDocumentProcessorTest.java
+++ b/api/src/test/java/org/openmrs/module/shr/cdahandler/processor/document/impl/ihe/pcc/test/AntepartumSummaryDocumentProcessorTest.java
@@ -42,6 +42,7 @@ public class AntepartumSummaryDocumentProcessorTest extends BaseModuleContextSen
 
 		GlobalProperty saveDir = new GlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_COMPLEX_OBS_DIR, "C:\\data\\");
 		Context.getAdministrationService().setGlobalProperty(CdaHandlerConfiguration.PROP_VALIDATE_CONCEPT_STRUCTURE, "false");
+        Context.getAdministrationService().setGlobalProperty("shr-cdahandler.cacheMappedConcepts", "false");
 		Context.getAdministrationService().saveGlobalProperty(saveDir);
 		executeDataSet(ACTIVE_LIST_INITIAL_XML);
 		executeDataSet(CIEL_LIST_INITIAL_XML);

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>shr-cdahandler</artifactId>
-		<version>0.5.0</version>
+		<version>0.5.1</version>
 	</parent>
 
 	<artifactId>shr-cdahandler-omod</artifactId>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>shr-cdahandler</artifactId>
-		<version>0.5.1</version>
+		<version>0.6.0</version>
 	</parent>
 
 	<artifactId>shr-cdahandler-omod</artifactId>
@@ -73,7 +73,7 @@
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>shr-contenthandler-api</artifactId>
-			<version>2.0.0</version>
+			<version>2.2.0</version>
 			<type>jar</type>
 			<scope>provided</scope>
 		</dependency>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -150,5 +150,11 @@
 		</defaultValue>
 		<description>When true, instructs the SHR to update any existing data carrying the same ID as the inbound CDA document. The default is false, meaning the SHR will return an error when duplicate statements are included in the document (see PCC TF-2 for the proper way to replace data)</description>
 	</globalProperty>
+    <globalProperty>
+        <property>${project.parent.artifactId}.cacheMappedConcepts</property>
+        <defaultValue>true
+        </defaultValue>
+        <description>When true, mapped concepts are cached. When false, they are not. This helps greatly with performance, however, if concept mappings are updated or changed the server will need to be re-stared to clear the cache.</description>
+    </globalProperty>
 </module>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>shr-cdahandler</artifactId>
-	<version>0.5.1</version>
+	<version>0.6.0</version>
 	<packaging>pom</packaging>
 	<name>SHR CDA Handler Module</name>
 	<description>Provides content handling for CDA documents</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>shr-cdahandler</artifactId>
-	<version>0.5.0</version>
+	<version>0.5.1</version>
 	<packaging>pom</packaging>
 	<name>SHR CDA Handler Module</name>
 	<description>Provides content handling for CDA documents</description>


### PR DESCRIPTION
Hey @justin-fyfe what do you think of this simple caching to improve performance? I was able to get a 10 fold performance increase with this once the concepts are cached.

The problems are that if the concept dictionary changes then we will require a server re-start. However, I don't think that is the worst thing for an SHR.