### PR TITLE
Updated to new contenthandler api.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>shr-cdahandler</artifactId>
-		<version>0.6.0</version>
+		<version>0.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>shr-cdahandler-api</artifactId>
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>shr-contenthandler-api</artifactId>
-			<version>2.2.0</version>
+			<version>3.0.0-SNAPSHOT</version>
 			<type>jar</type>
 			<scope>provided</scope>
 		</dependency>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>shr-cdahandler</artifactId>
-		<version>0.6.0</version>
+		<version>0.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>shr-cdahandler-omod</artifactId>
@@ -73,7 +73,7 @@
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>shr-contenthandler-api</artifactId>
-			<version>2.2.0</version>
+			<version>3.0.0-SNAPSHOT</version>
 			<type>jar</type>
 			<scope>provided</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>shr-cdahandler</artifactId>
-	<version>0.6.0</version>
+	<version>0.7.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>SHR CDA Handler Module</name>
 	<description>Provides content handling for CDA documents</description>


### PR DESCRIPTION
@rcrichton if you could please review? thanks

Perhaps @justin-fyfe you can take a look as well if you're able to see if it makes sense? So we're basically trying to improve the error handling between the xds interface, content handler and cda handler to ensure that all the errors you're already capturing aren't lost and returned to the client in the xds response.